### PR TITLE
removing onClose prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,9 +168,6 @@ The function arguments include ```event```, ```leaf```.
 ```event``` is the click event.
 ```leaf``` is the item user clicked on. Includes name, id and all data the user inputs when they pass in the tree.
 
-#### onClose(function)
-This function will get call when use click the cross on the menu
-
 # Styles
 There is a default style sheet you can use if you so desire.
 `/src/infinity-menu.css`

--- a/src/infinity-menu.js
+++ b/src/infinity-menu.js
@@ -266,7 +266,6 @@ export default class InfinityMenu extends React.Component {
 			setSearchInput: this.setSearchInput,
 			stopSearching: this.stopSearching,
 			startSearching: this.startSearching,
-			onClose: this.props.onClose,
 				...this.props.headerProps
 		};
 		const headerContent = this.props.headerContent ? React.createElement(this.props.headerContent, headerProps) : null;
@@ -286,8 +285,7 @@ InfinityMenu.propTypes = {
 	onNodeMouseClick: React.PropTypes.func,
 	onLeafMouseClick: React.PropTypes.func,
 	onLeafMouseDown: React.PropTypes.func,
-	onLeafMouseUp: React.PropTypes.func,
-	onClose: React.PropTypes.func
+	onLeafMouseUp: React.PropTypes.func
 };
 
 InfinityMenu.defaultProps = {
@@ -296,6 +294,5 @@ InfinityMenu.defaultProps = {
 	onNodeMouseClick: ()=>{},
 	onLeafMouseClick: ()=>{},
 	onLeafMouseDown: ()=>{},
-	onLeafMouseUp: ()=>{},
-	onClose: ()=>{}
+	onLeafMouseUp: ()=>{}
 };

--- a/test/index.js
+++ b/test/index.js
@@ -10,7 +10,7 @@ describe("Test for infinity menu", function() {
 
 	let component;
 	let dom;
-	let onNodeMouseClickStub, onLeafMouseClickStub, onLeafMouseDownStub, onLeafMouseUpStub, onCloseStub;
+	let onNodeMouseClickStub, onLeafMouseClickStub, onLeafMouseDownStub, onLeafMouseUpStub;
 	class TestCustomComponent extends React.Component {
 		render() {
 			return (<div className="test-custom-component"/>);
@@ -70,14 +70,12 @@ describe("Test for infinity menu", function() {
 		onLeafMouseClickStub = sinon.stub();
 		onLeafMouseUpStub = sinon.stub();
 		onLeafMouseDownStub = sinon.stub();
-		onCloseStub = sinon.stub();
 		component = <InfinityMenu
 			tree={tree}
 			onNodeMouseClick={onNodeMouseClickStub}
 			onLeafMouseClick={onLeafMouseClickStub}
 			onLeafMouseUp={onLeafMouseUpStub}
 			onLeafMouseDown={onLeafMouseDownStub}
-			onClose={onCloseStub}
 			/>;
 		dom = TestUtils.renderIntoDocument(component);
 	});


### PR DESCRIPTION
Since you can now pass custom props for a header, there really is no use for this prop.

If you wanted to have a custom close handler, you would just define a function prop on `headerProps` called `onClose`, and trigger it within the custom `headerComponent`

we'll have to do a major bump with this after merging since it is a breaking API change

