### PR TITLE
adding in props for "emptyTreeComponentProps" and "emptyTreeComponent"; making test suite more modular

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ class Example extends React.Component {
 
 A tree to represent the folder structure.
 Here is the example data you could pass into the tree props.
-```
+```js
 [
 	{
 		name: "menu1", /*require*/
@@ -115,58 +115,88 @@ Here is the example data you could pass into the tree props.
 ];
 ```
 
-#### headerContent(component) subcomponent rendered above the tree
+#### headerContent(React Component)
+Subcomponent rendered above the tree.
 
 `headerContent` is passed in to `InfinityMenu`. It is rendered above the tree subcomponent.
 
-#### headerProps(object) additional props for headerContent
+#### headerProps(object)
+Additional props for headerContent.
 
-`headerProps` is an optional prop of InfinityMenu. The props in this object are passed as props to a `headerContent` component. This is useful when extending InfinityMenu.
+* `headerProps` is an optional prop of InfinityMenu. The props in this object are passed as props to a `headerContent` component. This is useful when extending InfinityMenu.
 
 Passing the following into InfinityMenu as the `headerProps` prop sets the `title` prop on the headerContent component.
-```
+```js
 {
 	title: "my great title"
 }
 ```
 
-#### customComponent is a React component the user can pass in.
+#### customComponent(React Component)
+A custom React component the user can pass in.
   * As the `customComponent` at the node level, you will receive props `key`,  `onClick`, `name`, `isOpen`, `data` and `isSearching`.
   * As the `customComponent` at the leaf level, you will receive props `key`, `onMouseDown`, `onMouseUp`, `onClick`, `name`, `icon` and `data`.
 
+
+#### filter(function)[node, searchInput]
+By default, when the menu is in searching mode, it will filter all nodes by whether their `name` is equal to the current `searchInput`. If the node `name` is equal to the `searchInput`, then the node will pass the filter and be displayed in tree (if it fails the filter, it will not be displayed in the tree).
+
+This allows the user to specify their own filtering criteria. When the menu is in search mode, every node will be run against the `filter()` function:
+* If the function returns `true`, the node will pass the filter, and be displayed in the tree.
+* If the function returns `false`, the node will fail the filter, and __will not__ be displayed in the tree.
+
+The function takes the following arguments:
+* ```node (object)``` is the folder(node) the user clicked on. Includes the following properties: `id`, `name`, `isOpen` and `children`.
+* ```searchInput (string)``` The current search term
+
+#### emptyTreeComponent (React Component)
+If the `tree` prop is an empty array or if the menu is in searching mode and no nodes match the filter, then the tree is considered "empty".
+
+By default, nothing will be displayed in an empty tree.
+
+However, if this prop is passed in, the specified component will be rendered when the tree is empty.
+
+This allows you have a very customized "empty tree" message/image.
+
+#### emptyTreeComponentProps (object)
+Allows you to specify props to pass to the `emptyTreeComponent`.
+
+By default, this is an empty object.
 
 
 #### onNodeMouseClick(function)[event, tree, node, level]
 This function will get call when user click on the folder(node).
 The function arguments include ```event```, ```tree```, ```node``` and ```level```.
-```event``` is the mouse click event.
-```tree``` is the updated tree, you should update your own tree accordingly.
-```node``` is the folder(node) the user clicked on. Including the id, name, isOpen and children.
-```level``` is the distance from the root.
+* ```event``` is the mouse click event.
+* ```tree``` is the updated tree, you should update your own tree accordingly.
+* ```node``` is the folder(node) the user clicked on. Including the id, name, isOpen and children.
+* ```level``` is the distance from the root.
 
 
 #### onLeafMouseClick(function)[event, leaf]
 Bind to the onClick on the leaf.
 This function will get call when user click on the item(leaf).
 The function arguments include ```event```, ```leaf```.
-```event``` is the click event.
-```leaf``` is the item user clicked on. Includes name, id and all data the user inputs when they pass in the tree.
+* ```event``` is the click event.
+* ```leaf``` is the item user clicked on. Includes name, id and all data the user inputs when they pass in the tree.
 
 
 #### onLeafMouseDown(function)[event, leaf]
 Bind to the onMouseDown on the leaf.
 This function will get call when user mouse down on the item(leaf).
 The function arguments include ```event```, ```leaf```.
-```event``` is the click event.
-```leaf``` is the item user clicked on. Includes name, id and all data the user inputs when they pass in the tree.
+* ```event``` is the click event.
+* ```leaf``` is the item user clicked on. Includes name, id and all data the user inputs when they pass in the tree.
 
 
 #### onLeafMouseUp(function)[event, leaf]
 Bind to the onMouseUp on the leaf.
 This function will get call when user mouse up on the item(leaf).
 The function arguments include ```event```, ```leaf```.
-```event``` is the click event.
-```leaf``` is the item user clicked on. Includes name, id and all data the user inputs when they pass in the tree.
+* ```event``` is the click event.
+* ```leaf``` is the item user clicked on. Includes name, id and all data the user inputs when they pass in the tree.
+
+
 
 # Styles
 There is a default style sheet you can use if you so desire.

--- a/src/infinity-menu.js
+++ b/src/infinity-menu.js
@@ -97,7 +97,8 @@ export default class InfinityMenu extends React.Component {
 
 	findFilted(trees, node, key) {
 		if (!node.children) {
-			if (node.name.toLowerCase().includes(this.state.search.searchInput.toLowerCase())) {
+			const nodeMatchesSearchFilter = this.props.filter(node, this.state.search.searchInput);
+			if (nodeMatchesSearchFilter) {
 				trees[key] = node;
 				return trees;
 			}
@@ -236,6 +237,27 @@ export default class InfinityMenu extends React.Component {
 		}
 	}
 	/*
+	 *  @function _renderBody
+	 *  @description Renders the body content
+	 */
+	renderBody(displayTree) {
+		const {
+			emptyTreeComponent,
+			emptyTreeComponentProps
+		} = this.props;
+
+		if (displayTree.length) {
+			return displayTree;
+		}
+		else if (emptyTreeComponent) {
+			const emptyTreeElement = React.createElement(emptyTreeComponent, emptyTreeComponentProps);
+			return emptyTreeElement;
+		}
+		else {
+			return null;
+		}
+	}
+	/*
 	 *  @function render
 	 *  @description React render method for creating infinity menu
 	 */
@@ -266,15 +288,17 @@ export default class InfinityMenu extends React.Component {
 			setSearchInput: this.setSearchInput,
 			stopSearching: this.stopSearching,
 			startSearching: this.startSearching,
-				...this.props.headerProps
+			...this.props.headerProps
 		};
+
+		const bodyContent = this.renderBody(displayTree);
 		const headerContent = this.props.headerContent ? React.createElement(this.props.headerContent, headerProps) : null;
 
 		return (
 			<div className="infinity-menu-container">
 				{headerContent}
 				<div className="infinity-menu-display-tree-container">
-					{displayTree}
+					{bodyContent}
 				</div>
 			</div>
 		);
@@ -283,7 +307,11 @@ export default class InfinityMenu extends React.Component {
 
 InfinityMenu.propTypes = {
 	tree: React.PropTypes.array,
+	headerContent: React.PropTypes.any,
 	headerProps: React.PropTypes.object,
+	emptyTreeComponent: React.PropTypes.any,
+	emptyTreeComponentProps: React.PropTypes.object,
+	filter: React.PropTypes.func,
 	onNodeMouseClick: React.PropTypes.func,
 	onLeafMouseClick: React.PropTypes.func,
 	onLeafMouseDown: React.PropTypes.func,
@@ -292,7 +320,11 @@ InfinityMenu.propTypes = {
 
 InfinityMenu.defaultProps = {
 	tree: [],
+	headerContent: null,
 	headerProps: {},
+	emptyTreeComponent: null,
+	emptyTreeComponentProps: {},
+	filter: (node, searchInput) => { node.name.toLowerCase().includes(searchInput.toLowerCase()) },
 	onNodeMouseClick: ()=>{},
 	onLeafMouseClick: ()=>{},
 	onLeafMouseDown: ()=>{},

--- a/test/basic-render.js
+++ b/test/basic-render.js
@@ -1,0 +1,71 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import TestUtils from "react-addons-test-utils";
+let shallowRenderer = TestUtils.createRenderer();
+import InfinityMenu from "../src/infinity-menu";
+import sinon from "sinon";
+import "should-sinon";
+
+describe("Basic render test", function() {
+
+	let component;
+	let dom;
+	let onNodeMouseClickStub, onLeafMouseClickStub, onLeafMouseDownStub, onLeafMouseUpStub;
+
+	before(function() {
+		const tree =
+		[
+			{
+				name: "menu1",
+				id: 1,
+				isOpen: true,
+				children: [
+					{
+						name: "submenu1",
+						id: 1,
+						isOpen: true,
+						children: [
+							{
+								name: "item1-1",
+								id: 1
+							},
+							{
+								name: "item1-2",
+								id: 2
+							}
+						]
+					},
+					{
+						name: "submenu2",
+						id: 2,
+						isOpen: true,
+						children: [
+							{
+								name: "item2-1",
+								id: 1
+							}
+						]
+					}
+				]
+			},
+			{
+				name: "menu2",
+				id: 2,
+				isOpen: true,
+				children: [
+					{
+						name: "item3-1",
+						id: 1
+					}
+				]
+			}
+		];
+		component = <InfinityMenu tree={tree} />;
+	});
+
+	it("should render correctly with folder tree", function () {
+		shallowRenderer.render(component);
+		var result = shallowRenderer.getRenderOutput();
+		result.props.className.should.equal("infinity-menu-container");
+	});
+});

--- a/test/custom-component-prop.js
+++ b/test/custom-component-prop.js
@@ -1,0 +1,59 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import TestUtils from "react-addons-test-utils";
+let shallowRenderer = TestUtils.createRenderer();
+import InfinityMenu from "../src/infinity-menu";
+import sinon from "sinon";
+import should from "should";
+import "should-sinon";
+
+describe("Custom Component prop", function() {
+	let component;
+	let dom;
+
+	before(function() {
+		const CustomComponent = () => {
+			return <div className="test-custom-component"></div>;
+		};
+		const tree = [
+			{
+				name: "menu1",
+				id: 1,
+				isOpen: true,
+				customComponent: CustomComponent,
+				children: [
+					{
+						name: "submenu1",
+						id: 1,
+						isOpen: true,
+						children: [
+							{
+								name: "item1-1",
+								id: 1
+							},
+							{
+								name: "item1-2",
+								id: 2
+							}
+						]
+					}
+				]
+			}
+		];
+		component = <InfinityMenu tree={tree} />;
+		dom = TestUtils.renderIntoDocument(component);
+	});
+
+	after(function() {
+		ReactDOM.unmountComponentAtNode(ReactDOM.findDOMNode(dom).parentNode);
+	});
+
+	it("should render the custom component", function () {
+		should.doesNotThrow(() => {
+			TestUtils.findRenderedDOMComponentWithClass(
+				dom,
+				"test-custom-component"
+			);
+		});
+	});
+});

--- a/test/empty-list-component-props.js
+++ b/test/empty-list-component-props.js
@@ -1,0 +1,54 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import TestUtils from "react-addons-test-utils";
+import InfinityMenu from "../src/infinity-menu";
+import sinon from "sinon";
+import should from "should";
+import "should-sinon";
+let shallowRenderer = TestUtils.createRenderer();
+
+describe("Empty List Component props", function() {
+	it("should render `emptyTreeComponent` prop if `tree` prop is empty Array", function() {
+		// Setup
+		const DummyEmptyTreeComponent = () => {
+			return <div className="dummy-empty-tree-component">Component Content</div>;
+		};
+		// Render
+		const menuComponent = <InfinityMenu
+			tree={[]}
+			emptyTreeComponent={DummyEmptyTreeComponent}
+		/>;
+		const dom = TestUtils.renderIntoDocument(menuComponent);
+
+		// Assert
+		should.doesNotThrow(() => {
+			TestUtils.findRenderedDOMComponentWithClass(
+				dom,
+				"dummy-empty-tree-component"
+			)
+		});
+	});
+
+	it("should render `emptyTreeComponent` prop with `emptyTreeComponentProps` props if `tree` prop is empty Array", function() {
+		// Setup
+		const DummyEmptyTreeComponent = ({name}) => {
+			return <div className="dummy-empty-tree-component">{name}</div>;
+		};
+		const dummyEmptyTreeComponentProps = {
+			name: "Test Name"
+		};
+		const menuComponent = <InfinityMenu
+			tree={[]}
+			emptyTreeComponent={DummyEmptyTreeComponent}
+			emptyTreeComponentProps={dummyEmptyTreeComponentProps}
+		/>;
+
+		// Render
+		const dom = TestUtils.renderIntoDocument(menuComponent);
+		const emptyTreeComponent = TestUtils.findRenderedDOMComponentWithClass(dom, "dummy-empty-tree-component");
+		const emptyTreeDOMElement = ReactDOM.findDOMNode(emptyTreeComponent);
+
+		// Assert
+		emptyTreeDOMElement.textContent.should.equal(dummyEmptyTreeComponentProps.name);
+	});
+});

--- a/test/header-props.js
+++ b/test/header-props.js
@@ -1,0 +1,27 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import TestUtils from "react-addons-test-utils";
+let shallowRenderer = TestUtils.createRenderer();
+import InfinityMenu from "../src/infinity-menu";
+import sinon from "sinon";
+import "should-sinon";
+
+describe("Header props", function() {
+	it("should render correctly pass headerProps to the headerContent", function () {
+		// Setup
+		const Doge = ({ breed }) => {
+			<div>{breed}</div>
+		};
+		const component = <InfinityMenu
+			headerProps={{breed: "shiba"}}
+			headerContent={Doge}
+		/>;
+
+		// Render
+		shallowRenderer.render(component);
+		const result = shallowRenderer.getRenderOutput();
+
+		// Assert
+		result.props.children[0].props.breed.should.equal("shiba");
+	});
+});

--- a/test/leaf-node-mouse-handler-props.js
+++ b/test/leaf-node-mouse-handler-props.js
@@ -2,30 +2,21 @@ import React from "react";
 import ReactDOM from "react-dom";
 import TestUtils from "react-addons-test-utils";
 let shallowRenderer = TestUtils.createRenderer();
-import InfinityMenu from "../dist/infinity-menu";
-import assert from "assert";
+import InfinityMenu from "../src/infinity-menu";
 import sinon from "sinon";
 import "should-sinon";
 
-describe("Test for infinity menu", function() {
-
+describe("Leaf/Node Mouse Handlers", function() {
 	let component;
 	let dom;
 	let onNodeMouseClickStub, onLeafMouseClickStub, onLeafMouseDownStub, onLeafMouseUpStub;
-	class TestCustomComponent extends React.Component {
-		render() {
-			return (<div className="test-custom-component"/>);
-		}
-	}
 
 	before(function() {
-		const tree =
-		[
+		const tree = [
 			{
 				name: "menu1",
 				id: 1,
 				isOpen: true,
-				customComponent: TestCustomComponent,
 				children: [
 					{
 						name: "submenu1",
@@ -81,31 +72,9 @@ describe("Test for infinity menu", function() {
 		dom = TestUtils.renderIntoDocument(component);
 	});
 
-	it("should render correctly pass headerProps to the headerContent", function () {
-		class Doge extends React.Component{
-			render() {
-				return (
-					<div>{this.props.breed}</div>
-				);
-			}
-		}
-
-		component = <InfinityMenu
-			headerProps={{breed: "shiba"}}
-			headerContent={Doge}
-			/>;
-		shallowRenderer.render(component);
-		const result = shallowRenderer.getRenderOutput();
-		assert.equal(result.props.children[0].props.breed, "shiba");
+	after(function() {
+		ReactDOM.unmountComponentAtNode(ReactDOM.findDOMNode(dom).parentNode);
 	});
-
-
-	it("should render correctly with folder tree", function () {
-		shallowRenderer.render(component);
-		var result = shallowRenderer.getRenderOutput();
-		assert.equal(result.props.className, "infinity-menu-container");
-	});
-
 
 	it("should call onNodeMouseClick function", function () {
 		var folderNode = ReactDOM.findDOMNode(
@@ -116,8 +85,6 @@ describe("Test for infinity menu", function() {
 		);
 		onNodeMouseClickStub.should.have.callCount(0);
 		TestUtils.Simulate.click(folderNode);
-		/*the fourth argument is the level of current node*/
-		onNodeMouseClickStub.args[0][3].should.equal(1);
 		onNodeMouseClickStub.should.have.callCount(1);
 	});
 
@@ -157,12 +124,4 @@ describe("Test for infinity menu", function() {
 		onLeafMouseUpStub.should.have.callCount(1);
 	});
 
-	it("should have test-custom-component", function () {
-		assert.doesNotThrow(() => {
-			TestUtils.findRenderedDOMComponentWithClass(
-				dom,
-				"test-custom-component"
-			);
-		});
-	});
 });


### PR DESCRIPTION
This PR includes the following:

* adds in props for `emptyTreeComponentProps` and `emptyTreeComponent`. 
The `emptyTreeComponent` allows you to specify a component to render when `tree` is empty, or no nodes in the tree match the filter. For example, if no entries match the filter, you can have the component like this render:
![image](https://cloud.githubusercontent.com/assets/437318/11984408/ea3a8eba-a988-11e5-8be5-598bbd19ac8e.png)

* Breaks the tests from a single `index.js` file into more modular files based on specific functionality being tested. This will make managing the new tests/adding new tests much easier

* Adds a new `filter` prop that allows you to specify the filter criteria. Previously, the filter would automatically filter with the node name === to the search term input. I refactored it such that `filter` is a function that takes the searchTerm and the node as input. If the function returns `true`, the node passes the filter and is displayed, if the node returns `false`, it is not shown.

* Various `README` cleanups