### PR TITLE
Changing 'boolean' to 'bool' so React.PropTypes don't complain

### DIFF
--- a/src/infinity-menu.js
+++ b/src/infinity-menu.js
@@ -313,7 +313,7 @@ export default class InfinityMenu extends React.Component {
 InfinityMenu.propTypes = {
 	tree: React.PropTypes.array,
 	headerContent: React.PropTypes.any,
-	disableDefaultHeaderContent: React.PropTypes.boolean,
+	disableDefaultHeaderContent: React.PropTypes.bool,
 	headerProps: React.PropTypes.object,
 	customComponentMappings: React.PropTypes.object,
 	emptyTreeComponent: React.PropTypes.any,


### PR DESCRIPTION
Hey @tiansijie, I was working on this and just noticed a recurring React.PropType warning and found the small bug in your PropType definitions.