### PR TITLE
Some thoughts for a load more option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ class Example extends React.Component {
 				onLeafMouseClick={this.onLeafMouseClick}/*optional*/
 				onLeafMouseDown={this.onLeafMouseDown}/*optional*/
 				onLeafMouseUp={this.onLeafMouseUp}/*optional*/
+				maxLeaves={5}/*optional*/
 			/>
 		);
 	}
@@ -221,6 +222,12 @@ This function will get call when user mouse up on the item(leaf).
 The function arguments include ```event```, ```leaf```.
 * ```event``` is the click event.
 * ```leaf``` is the item user clicked on. Includes name, id, keyPath and all data the user inputs when they pass in the tree.
+
+
+
+#### maxLeaves(integer)
+Sets the maximum number of leaf to show initially.  Also used as an increment when then load more is pressed.
+
 
 #### shouldComponentUpdate(function) [currProps, currState, nextProps, nextState]
 A function that will be called inside shouldComponentUpdate. It's a good place to optimize update.

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -2,6 +2,82 @@ import React from "react";
 import ReactDOM from "react-dom";
 import "../../src/infinity-menu.css";
 import InfinityMenu from "../../src/infinity-menu";
+const tree2 = [
+	{
+		name: "Menu1",
+		id: 0,
+		isOpen: true,
+		children: [
+			{
+				name: "SubMenu1-1",
+				id: 0,
+				isOpen: true,
+				children: [
+					{
+						name: "Sub-SubMenu1-6",
+						id: 5
+					},
+					{
+						name: "Sub-SubMenu1-7",
+						id: 6
+					},
+					{
+						name: "Sub-SubMenu1-8",
+						id: 7
+					},
+					{
+						name: "Sub-SubMenu1-9",
+						id: 8
+					}
+				]
+			},
+			{
+				name: "SubMenu2-1",
+				id: 1,
+				children: [
+					{
+						name: "Sub-SubMenu2-1",
+						id: 0
+					}
+				]
+			}
+		]
+	},
+	{
+		name: "Menu2",
+		id: 1,
+		isOpen: false,
+		children: [
+			{
+				name: "SubMenu2-1",
+				id: 0
+			},
+			{
+				name: "SubMenu2-2",
+				id: 1
+			},
+			{
+				name: "SubMenu2-3",
+				id: 2
+			}
+		]
+	},
+	{
+		name: "Menu3",
+		id: 2,
+		isOpen: false,
+		children: [
+			{
+				name: "SubMenu3-1",
+				id: 0
+			},
+			{
+				name: "SubMenu3-2",
+				id: 1
+			}
+		]
+	}
+];
 
 class App extends React.Component {
 
@@ -105,6 +181,11 @@ class App extends React.Component {
 		this.setState({
 			tree: tree
 		});
+		setTimeout(() => {
+			this.setState({
+				tree: tree2
+			})
+		}, 10000)
 	}
 
 	onNodeMouseClick(event, tree) {

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -52,6 +52,14 @@ class App extends React.Component {
 							{
 								name: "Sub-SubMenu1-9",
 								id: 8
+							},
+							{
+								name: "Sub-SubMenu1-99",
+								id: 9
+							},
+							{
+								name: "Sub-SubMenu1-999",
+								id: 10
 							}
 						]
 					},

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -28,6 +28,30 @@ class App extends React.Component {
 							{
 								name: "Sub-SubMenu1-3",
 								id: 2
+							},
+							{
+								name: "Sub-SubMenu1-4",
+								id: 3
+							},
+							{
+								name: "Sub-SubMenu1-5",
+								id: 4
+							},
+							{
+								name: "Sub-SubMenu1-6",
+								id: 5
+							},
+							{
+								name: "Sub-SubMenu1-7",
+								id: 6
+							},
+							{
+								name: "Sub-SubMenu1-8",
+								id: 7
+							},
+							{
+								name: "Sub-SubMenu1-9",
+								id: 8
 							}
 						]
 					},
@@ -94,6 +118,7 @@ class App extends React.Component {
 			<InfinityMenu
 				tree={this.state.tree}
 				onNodeMouseClick={this.onNodeMouseClick.bind(this)}
+				maxLeaves={2}
 			/>
 		);
 	}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/socialtables/react-infinity-menu",
   "dependencies": {
-    "nested-objects": "0.0.2"
+    "lodash": "^4.16.2"
   },
   "devDependencies": {
     "babel": "^5.8.23",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "mocha --compilers js:babel/register --recursive",
     "build": "babel src -d dist",
     "watch": "babel src --watch -d dist",
-    "dev": "webpack --watch",
+    "dev": "webpack --port 666 --watch",
     "prepublish": "npm run build"
   },
   "repository": {
@@ -20,12 +20,14 @@
   },
   "homepage": "https://github.com/socialtables/react-infinity-menu",
   "dependencies": {
+    "babel-preset-es2015": "^6.16.0",
+    "babel-preset-react": "^6.16.0",
     "lodash": "^4.16.2"
   },
   "devDependencies": {
     "babel": "^5.8.23",
     "babel-core": "^5.8.25",
-    "babel-loader": "^5.3.2",
+    "babel-loader": "^5.4.2",
     "css-loader": "^0.21.0",
     "eslint": "^0.23.0",
     "eslint-loader": "^0.14.0",

--- a/package.json
+++ b/package.json
@@ -21,14 +21,15 @@
   "homepage": "https://github.com/socialtables/react-infinity-menu",
   "dependencies": {
     "lodash": "^4.16.2",
-		"nested-objects":"0.0.2"
+    "nested-objects": "0.0.2"
   },
   "devDependencies": {
     "babel": "^5.8.23",
     "babel-core": "^5.8.25",
     "babel-loader": "^5.4.2",
-	  "babel-preset-es2015": "^6.16.0",
+    "babel-preset-es2015": "^6.16.0",
     "babel-preset-react": "^6.16.0",
+    "babel-preset-stage-0": "^6.16.0",
     "css-loader": "^0.21.0",
     "eslint": "^0.23.0",
     "eslint-loader": "^0.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-infinity-menu",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "An unlimited deep side menu",
   "main": "./dist/infinity-menu.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-infinity-menu",
-  "version": "2.2.5",
+  "version": "2.3.0",
   "description": "An unlimited deep side menu",
   "main": "./dist/infinity-menu.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -26,10 +26,7 @@
   "devDependencies": {
     "babel": "^5.8.23",
     "babel-core": "^5.8.25",
-    "babel-loader": "^5.4.2",
-    "babel-preset-es2015": "^6.16.0",
-    "babel-preset-react": "^6.16.0",
-    "babel-preset-stage-0": "^6.16.0",
+    "babel-loader": "^5.3.2",
     "css-loader": "^0.21.0",
     "eslint": "^0.23.0",
     "eslint-loader": "^0.14.0",
@@ -41,9 +38,9 @@
     "react-dom": "^0.14.3",
     "should": "^7.1.0",
     "should-sinon": "0.0.3",
-    "sinon": "^1.17.6",
-    "style-loader": "^0.13.1",
-    "webpack": "^1.13.3"
+    "sinon": "^1.17.1",
+    "style-loader": "^0.13.0",
+    "webpack": "^1.12.2"
   },
   "peerDependencies": {
     "react": ">=0.13.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-infinity-menu",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "An unlimited deep side menu",
   "main": "./dist/infinity-menu.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/socialtables/react-infinity-menu",
   "dependencies": {
-    "lodash": "^4.16.2",
+    "lodash": "^4.16.6",
     "nested-objects": "0.0.2"
   },
   "devDependencies": {
@@ -41,9 +41,9 @@
     "react-dom": "^0.14.3",
     "should": "^7.1.0",
     "should-sinon": "0.0.3",
-    "sinon": "^1.17.1",
-    "style-loader": "^0.13.0",
-    "webpack": "^1.12.2"
+    "sinon": "^1.17.6",
+    "style-loader": "^0.13.1",
+    "webpack": "^1.13.3"
   },
   "peerDependencies": {
     "react": ">=0.13.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-infinity-menu",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "An unlimited deep side menu",
   "main": "./dist/infinity-menu.js",
   "scripts": {

--- a/src/infinity-menu.css
+++ b/src/infinity-menu.css
@@ -25,3 +25,19 @@
 .infinity-menu-leaf-container:hover {
 	background-color: rgb(73, 73, 73);
 }
+
+.infinity-menu-load-more-container {
+	width: 100%;
+	background-color: rgb(255, 255, 255);
+	color: rgb(94, 96, 99);
+	height: 30px;
+	padding-left: 20px;
+	padding-top: 15px;
+	border-bottom: solid 1px rgb(73, 73 ,73);
+	text-align: center;
+	list-style-type: none;
+}
+
+.infinity-menu-load-more-container:hover {
+	background-color: rgb(200, 200, 200);
+}

--- a/src/infinity-menu.css
+++ b/src/infinity-menu.css
@@ -33,7 +33,6 @@
 	height: 30px;
 	padding-left: 20px;
 	padding-top: 15px;
-	border-bottom: solid 1px rgb(73, 73 ,73);
 	text-align: center;
 	list-style-type: none;
 }

--- a/src/infinity-menu.js
+++ b/src/infinity-menu.js
@@ -170,8 +170,9 @@ export default class InfinityMenu extends React.Component {
 
 			let relativeIndex = visIds.indexOf(curr.id)
 			relativeIndex = (relativeIndex === -1) ? Infinity : relativeIndex
-
-			if (shouldDisplay && parentNode.maxLeaves > relativeIndex ) {
+			// console.log(relativeIndex, visIds, parentNode.maxLeaves)
+			let parentMaxLeaves = parentNode.maxLeaves || this.props.maxLeaves
+			if (shouldDisplay && parentMaxLeaves > relativeIndex ) {
 				if (curr.customComponent) {
 					const componentProps = {
 						key: itemKey,
@@ -380,7 +381,8 @@ InfinityMenu.propTypes = {
 	onLeafMouseClick: React.PropTypes.func,
 	onLeafMouseDown: React.PropTypes.func,
 	onLeafMouseUp: React.PropTypes.func,
-	shouldComponentUpdate: React.PropTypes.func
+	shouldComponentUpdate: React.PropTypes.func,
+	maxLeaves: React.PropTypes.number
 };
 
 InfinityMenu.defaultProps = {
@@ -394,5 +396,6 @@ InfinityMenu.defaultProps = {
 	onNodeMouseClick: ()=>{},
 	onLeafMouseClick: ()=>{},
 	onLeafMouseDown: ()=>{},
-	onLeafMouseUp: ()=>{}
+	onLeafMouseUp: ()=>{},
+	maxLeaves: Infinity
 };

--- a/src/infinity-menu.js
+++ b/src/infinity-menu.js
@@ -33,9 +33,7 @@ export default class InfinityMenu extends React.Component {
 		event.preventDefault();
 		if (!this.state.search.isSearching || !this.state.search.searchInput.length) {
 			node.isOpen = !node.isOpen;
-			if (!node.isOpen || node.children && !node.maxLeaves) {
-				node.maxLeaves = this.props.maxLeaves;
-			}
+			node.maxLeaves = this.props.maxLeaves;
 			NestedObjects.set(tree, keyPath, node);
 			if (this.props.onNodeMouseClick) {
 				const currLevel = Math.floor(keyPath.split(".").length / 2);
@@ -46,15 +44,15 @@ export default class InfinityMenu extends React.Component {
 
 	onLoadMoreClick(tree, node, keyPath, event) {
 		event.preventDefault();
+		// get parent node so we can increment it's unique max leaves property
 		const keyPathArray = keyPath.split('.')
 		const parentPath = Object.assign([],keyPathArray).splice(0, keyPathArray.length - 2)
 		const parentNode = _.get(this.props.tree, parentPath)
-		if (parentNode) {
-			parentNode.maxLeaves = (!parentNode.maxLeaves) ? this.props.maxLeaves : parentNode.maxLeaves + this.props.maxLeaves;
-			if (this.props.onNodeMouseClick) {
-				const currLevel = Math.floor(keyPath.split(".").length / 2);
-				this.props.onNodeMouseClick(event, tree, node, currLevel, keyPath);
-			}
+		// set new max leaves - if none exist use component default property
+		parentNode.maxLeaves = (!parentNode.maxLeaves) ? this.props.maxLeaves : parentNode.maxLeaves + this.props.maxLeaves;
+		if (this.props.onNodeMouseClick) {
+			const currLevel = Math.floor(keyPath.split(".").length / 2);
+			this.props.onNodeMouseClick(event, tree, node, currLevel, keyPath);
 		}
 	}
 	/*
@@ -172,7 +170,7 @@ export default class InfinityMenu extends React.Component {
 
 			let relativeIndex = visIds.indexOf(curr.id)
 			relativeIndex = (relativeIndex === -1) ? Infinity : relativeIndex
-			// console.log(relativeIndex, visIds, parentNode.maxLeaves)
+
 			let parentMaxLeaves = parentNode.maxLeaves || this.props.maxLeaves
 			if (shouldDisplay && parentMaxLeaves > relativeIndex ) {
 				if (curr.customComponent) {

--- a/src/infinity-menu.js
+++ b/src/infinity-menu.js
@@ -2,7 +2,6 @@ import React from "react";
 import SearchInput from "./search-input";
 import NestedObjects from "nested-objects";
 import _ from 'lodash'
-// import NestedObjects from "nested-objects";
 
 /*
  *  @class InfinityMenu
@@ -153,6 +152,7 @@ export default class InfinityMenu extends React.Component {
 	setDisplayTree(tree, prevs, curr, keyPath) {
 		const currLevel = Math.floor(keyPath.length / 2);
 		const currCustomComponent = typeof curr.customComponent === 'string' ? this.props.customComponentMappings[curr.customComponent] : curr.customComponent;
+		const currCustomloadMoreComponent = (this.props.loadMoreComponent) ? this.props.loadMoreComponent : null
 		const isSearching = this.state.search.isSearching && this.state.search.searchInput;
 		const shouldDisplay = (isSearching && curr.isSearchDisplay) || !isSearching;
 		/*the leaves*/
@@ -199,16 +199,13 @@ export default class InfinityMenu extends React.Component {
 				}
 			} else {
 				if (relativeIndex === filteredChildren.length - 1) {
-					if (this.props.loadMoreComponent) {
-							prevs.push(
-							<div key={itemKey}
-								onClick={this.onLoadMoreClick.bind(this, tree, curr, keyPath)}
-							>
-								{
-									this.props.loadMoreComponent//not really a component yet...
-								}
-							</div>
-						)
+					if (currCustomloadMoreComponent) {
+							const loadMoreProps = {
+								key: itemKey,
+								onClick: this.onLoadMoreClick.bind(this, tree, curr, keyPath)
+							};
+							prevs.push(React.createElement(currCustomloadMoreComponent, loadMoreProps));
+
 					} else {
 						prevs.push(
 							<li key={itemKey}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,6 +13,13 @@ module.exports = {
     loaders: [
       { test: /\.js$/, exclude: /node_modules/, loader: 'babel-loader?optional=es7.objectRestSpread'},
       { test: /\.css$/, loader: "style-loader!css-loader" }
-    ]
+    ],
+    query: {
+      presets: [
+        'babel-preset-es2015',
+        'babel-preset-react',
+        'babel-preset-stage-0',
+      ].map(require.resolve),
+    }
   }
 };


### PR DESCRIPTION
This is an incomplete but workable proof of concept for fixes #33 .  Added added a quantifier property to the top level component which is pushed down to a new property on branch nodes to track how many leafs should be visible.  Load more increments that value and displays the indexes in the visible range.  Should work with the search but I'm not using that feature in production.  
